### PR TITLE
feat(tags): add tags support for blog posts

### DIFF
--- a/components/layout.js
+++ b/components/layout.js
@@ -2,9 +2,14 @@ import { useEffect } from "react";
 import Head from "next/head";
 import Link from "next/link";
 import Image from "next/image";
-import { Heading, Text, Avatar, useTheme } from "spartak-ui";
+import { Button, Heading, Text, Avatar, useTheme } from "spartak-ui";
 import { Toggle } from "./toggle";
-import { invertSvg, reduceImageBrightness, invertBackgroundCodeColor } from "../themes/helpers";
+import { IconArrowLeft } from "@tabler/icons-react";
+import {
+  invertSvg,
+  reduceImageBrightness,
+  invertBackgroundCodeColor,
+} from "../themes/helpers";
 
 import styles from "./layout.module.css";
 import utilStyles from "../styles/utils.module.css";
@@ -70,9 +75,16 @@ export default function Layout({ children, home }) {
       </>
       <main>{children}</main>
       {!home && (
-        <Text as={Link} href="/" size="md" color="red">
-          ← Back to home
-        </Text>
+        <Button
+          icon={<IconArrowLeft size={18} />}
+          variant="text"
+          as={Link}
+          href="/"
+          size="md"
+          color="red"
+        >
+          Main page
+        </Button>
       )}
     </div>
   );

--- a/lib/posts.js
+++ b/lib/posts.js
@@ -28,6 +28,60 @@ export function getSortedPostsData() {
   return allPostsData.sort((a, b) => (a.date < b.date ? 1 : -1));
 }
 
+export function getAllPostTags() {
+  const fileNames = fs.readdirSync(postsDirectory);
+
+  const tags = new Set();
+
+  fileNames.forEach((fileName) => {
+    // Read markdown file as string
+    const fullPath = path.join(postsDirectory, fileName);
+    const fileContents = fs.readFileSync(fullPath, "utf8");
+
+    // Use gray-matter to parse the post metadata section
+    const matterResult = matter(fileContents);
+
+    if (matterResult.data?.tags) {
+      for (const tag of matterResult.data.tags) tags.add(tag);
+    }
+  });
+
+  const tagsMap = new Map();
+  for (const tag of tags) {
+    tagsMap.set(tag.split(" ").join("-"), tag);
+  }
+
+  // returns map with tag pairs "path tag": "actual tag" { "micro-front-end": "micro front-end" }
+  return tagsMap;
+}
+
+export function getSortedPostsDataByTag(tag) {
+  // Get file names under /posts
+  const fileNames = fs.readdirSync(postsDirectory);
+  const tagsMap = getAllPostTags();
+  const allPostsData = fileNames
+    .map((fileName) => {
+      // Remove ".md" from file name to get id
+      const id = fileName.replace(/\.md$/, "");
+
+      // Read markdown file as string
+      const fullPath = path.join(postsDirectory, fileName);
+      const fileContents = fs.readFileSync(fullPath, "utf8");
+
+      // Use gray-matter to parse the post metadata section
+      const matterResult = matter(fileContents);
+
+      // Combine the data with the id
+      return {
+        id,
+        ...matterResult.data,
+      };
+    })
+    .filter((post) => post?.tags?.includes(tagsMap.get(tag)));
+  // Sort posts by date
+  return allPostsData.sort((a, b) => (a.date < b.date ? 1 : -1));
+}
+
 export function getAllPostIds() {
   const fileNames = fs.readdirSync(postsDirectory);
 
@@ -59,7 +113,7 @@ export async function getPostData(id) {
 
   // Use gray-matter to parse the post metadata section
   const matterResult = matter(fileContents);
-  
+
   const contentMarkdown = matterResult.content;
 
   // Combine the data with the id and contentHtml

--- a/markdown/free-online-courses-for-developers-in-2021.md
+++ b/markdown/free-online-courses-for-developers-in-2021.md
@@ -3,7 +3,7 @@ title: "Free Online Courses for Developers to Take in 2021"
 date: "2021-07-13"
 excerpt: "Collection of free online courses I recommend for developers to take in 2021"
 image: "https://cdn-images-1.medium.com/max/2400/1*gLrR5dyOouzLvJYfhIWd7A.jpeg"
-tags: ["education", "online courses"]
+tags: ["online courses", "javascript", "frontend", "fullstack", "computer science"]
 ---
 
 ![Navigating with a compass in Yosemite National Park](https://cdn-images-1.medium.com/max/2400/1*gLrR5dyOouzLvJYfhIWd7A.jpeg "Navigating with a compass in Yosemite National Park")

--- a/markdown/how-to-achieve-goals-while-developing-soft-skills.md
+++ b/markdown/how-to-achieve-goals-while-developing-soft-skills.md
@@ -3,6 +3,7 @@ title: "How to Achieve Goals while Developing Soft Skills"
 date: "2020-10-07"
 excerpt: "The article about setting and achieving goals while staying focused and developing soft skills"
 image: "https://cdn-images-1.medium.com/max/2400/1*_16W2oRZENDqOK9kn-l6lQ.jpeg"
+tags: ["soft skills"]
 ---
 
 ![The Vessel](https://cdn-images-1.medium.com/max/2400/1*_16W2oRZENDqOK9kn-l6lQ.jpeg "The Vessel, New York City")

--- a/markdown/optimizing-svg-for-dark-mode.md
+++ b/markdown/optimizing-svg-for-dark-mode.md
@@ -3,7 +3,7 @@ title: "Optimizing SVG Images for Dark Mode: Inverting Colors with CSS and JavaS
 date: "2023-05-13"
 excerpt: "Learn how to optimize SVG images for dark mode by inverting colors with CSS and JavaScript. This article provides easy-to-follow steps to ensure your SVG images remain visible regardless of the user's preferred theme."
 image: ""
-tags: ["front-end", "javascript", "react", "css", "svg"]
+tags: ["frontend", "javascript", "react", "css", "svg"]
 ---
 
 ## Understanding the problem

--- a/pages/[id].js
+++ b/pages/[id].js
@@ -7,7 +7,7 @@ import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import dark from "react-syntax-highlighter/dist/cjs/styles/prism/tomorrow";
 import light from "react-syntax-highlighter/dist/cjs/styles/prism/one-light";
 
-import { Heading, Text, useTheme } from "spartak-ui";
+import { Heading, Text, Badge, useTheme } from "spartak-ui";
 import { getAllPostIds, getPostData } from "../lib/posts";
 
 import Layout from "../components/layout";
@@ -15,6 +15,15 @@ import Date from "../components/date";
 
 export default function Post({ postData }) {
   const { theme } = useTheme();
+
+  const tags = postData.tags || [];
+  const badges = tags.map((tag) => (
+    <Link href={`/tag/${tag.split(" ").join("-")}`} key={tag}>
+      <Badge css={{ margin: "0 5px 0 0" }} variant="outlined" color="green">
+        {tag.toLowerCase()}
+      </Badge>
+    </Link>
+  ));
 
   return (
     <Layout>
@@ -29,12 +38,13 @@ export default function Post({ postData }) {
         <meta name="twitter:card" content="summary_large_image" />
       </Head>
       <article>
-        <Heading as="h1" size="xl" css={{ paddingBottom: "$paddingLG" }}>
+        <Heading as="h1" size="xl" css={{ paddingBottom: "$paddingXS" }}>
           {postData.title}
         </Heading>
-        <Text secondary size="md">
+        <Text css={{ paddingBottom: "$paddingXS" }} secondary size="md">
           <Date dateString={postData.date} />
         </Text>
+        {badges.length > 0 && <>{badges}</>}
         <ReactMarkdown
           rehypePlugins={[rehypeRaw]}
           components={{

--- a/pages/index.js
+++ b/pages/index.js
@@ -3,11 +3,24 @@ import Link from "next/link";
 import Layout, { siteTitle } from "../components/layout";
 import Date from "../components/date";
 import utilStyles from "../styles/utils.module.css";
-import { getSortedPostsData } from "../lib/posts";
-import { Heading, Text } from "spartak-ui";
+import { getAllPostTags, getSortedPostsData } from "../lib/posts";
+import { Badge, Heading, Text } from "spartak-ui";
 
+export default function Home({ allPostsData, allTags }) {
+  const tags = allTags || [];
+  const badges = tags.map((tag) => (
+    <Link href={`/tag/${tag.split(" ").join("-")}`} key={tag}>
+      <Badge
+        size="md"
+        css={{ margin: "8px 4px 0 0" }}
+        variant="outlined"
+        color="green"
+      >
+        {tag.toLowerCase()}
+      </Badge>
+    </Link>
+  ));
 
-export default function Home({ allPostsData }) {
   return (
     <Layout home>
       <Head>
@@ -15,8 +28,7 @@ export default function Home({ allPostsData }) {
       </Head>
       <section className={utilStyles.headingMd}>
         <Text size="xl" align="center" secondary>
-          Frontend Engineer, Google certified Mobile Web
-          Specialist
+          Frontend Engineer, Google certified Mobile Web Specialist
         </Text>
         <Text size="xl" align="center" secondary>
           Typescript &#183; Javascript &#183; React &#183; Node.js
@@ -68,15 +80,22 @@ export default function Home({ allPostsData }) {
           ))}
         </ul>
       </section>
+      <section>
+        <Heading size="xl">Topics</Heading>
+        {badges}
+      </section>
     </Layout>
   );
 }
 
 export async function getStaticProps() {
   const allPostsData = getSortedPostsData();
+  const tagsMap = getAllPostTags();
+  const allTags = [...tagsMap.values()];
   return {
     props: {
       allPostsData,
+      allTags,
     },
   };
 }

--- a/pages/tag/[tag].js
+++ b/pages/tag/[tag].js
@@ -1,0 +1,61 @@
+import Head from "next/head";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { getAllPostTags, getSortedPostsDataByTag } from "../../lib/posts";
+import utilStyles from "../../styles/utils.module.css";
+import Date from "../../components/date";
+
+import Layout from "../../components/layout";
+import { Heading, Text } from "spartak-ui";
+
+export default function Tag({ allTaggedPostsData }) {
+  const router = useRouter();
+  const tag = router.query.tag;
+  return (
+    <Layout>
+      <Head>
+        <title>Posts about {tag}</title>
+      </Head>
+      <Heading as="h1" size="xl" css={{ paddingBottom: "$paddingXS" }}>
+        Posts about {tag}
+      </Heading>
+      <ul className={utilStyles.list}>
+        {allTaggedPostsData.map(({ id, date, title }) => (
+          <li className={utilStyles.listItem} key={id}>
+            <Text as={Link} href={`/${id}`} size="xl" color="red">
+              {title}
+            </Text>
+            <Text size="md" secondary css={{ paddingTop: "5px" }}>
+              <Date dateString={date} />
+            </Text>
+          </li>
+        ))}
+      </ul>
+    </Layout>
+  );
+}
+
+export async function getStaticPaths() {
+  const tagsMap = getAllPostTags();
+  const paths = [...tagsMap.keys()].map((tag) => {
+    return {
+      params: {
+        tag: tag,
+      },
+    };
+  });
+  return {
+    paths,
+    fallback: false,
+  };
+}
+
+export async function getStaticProps({ params }) {
+  const tag = params.tag;
+  const allTaggedPostsData = getSortedPostsDataByTag(tag);
+  return {
+    props: {
+      allTaggedPostsData,
+    },
+  };
+}


### PR DESCRIPTION
**Description**

This PR adds support for post tags.
A dynamic page for `cherniaev.com/tag/<tag-name>` URL added.
All tags on the main page and tags inside posts are `Badge` components from [Spartak-UI](https://github.com/shdq/spartak-ui).